### PR TITLE
Centralize ossf scan to .github repo

### DIFF
--- a/.github/workflows/ossf-analysis.yml
+++ b/.github/workflows/ossf-analysis.yml
@@ -15,3 +15,9 @@ permissions: read-all
 jobs:
   analysis:
     uses: devops-actions/.github/.github/workflows/rw-ossf-scorecard.yml@main
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      id-token: write
+      actions: read
+      contents: read

--- a/.github/workflows/ossf-analysis.yml
+++ b/.github/workflows/ossf-analysis.yml
@@ -1,4 +1,4 @@
-name: Scorecards supply-chain security
+name: Scorecards supply-chain security scan
 on:
   # Only the default branch is supported.
   branch_protection_rule:
@@ -14,50 +14,4 @@ permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecards analysis
-    runs-on: ubuntu-latest
-    permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Used to receive a badge. (Upcoming feature)
-      id-token: write
-      actions: read
-      contents: read
-
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # tag=v3.0.0
-        with:
-          persist-credentials: false
-
-      - name: "Run analysis"
-        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # tag=v2.1.2
-        with:
-          results_file: results.sarif
-          results_format: sarif
-          # (Optional) "write" PAT token. Uncomment the `repo_token` line below if:
-          # - you want to enable the Branch-Protection check on a *public* repository, or
-          # - you are installing Scorecards on a *private* repository
-          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
-
-          # Publish the results for public repositories to enable scorecard badges. For more details, see
-          # https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories, `publish_results` will automatically be set to `false`, regardless
-          # of the value entered here.
-          publish_results: true
-
-      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
-      # format to the repository Actions tab.
-      - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # tag=v3.0.0
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 7
-
-      # Upload the results to GitHub's code scanning dashboard.
-      - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@32dc499307d133bb5085bae78498c0ac2cf762d5 # tag=v1.0.26
-        with:
-          sarif_file: results.sarif
+    uses: devops-actions/.github/.github/workflows/rw-ossf-scorecard.yml@main


### PR DESCRIPTION
Single definition in one place