### PR TITLE
Upgrade action to run on node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   tag:
     description: Git tag name
 runs:
-  using: node16
+  using: node20
   main: main.js


### PR DESCRIPTION
Closes #69

Upgrades the GitHub Action to run on Node20 by modifying the `action.yml` file.
- Updates the `runs.using` field from `node16` to `node20` to align with the latest Node.js version requirement.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/devops-actions/action-get-tag/issues/69?shareId=a1d9d62f-e3d8-4b93-b3fa-1fd674409d13).