### PR TITLE
Add standard workflows using reusable workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,13 @@
+name: Lint GitHub Actions workflows
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  actionlint:
+    uses: devops-actions/.github/.github/workflows/actionlint.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/actions-dependencies.yml
+++ b/.github/workflows/actions-dependencies.yml
@@ -1,0 +1,19 @@
+name: Submit Actions Dependencies
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1' # Weekly
+
+permissions:
+  contents: read
+  
+jobs:
+  submit-dependencies:
+    uses: devops-actions/.github/.github/workflows/actions-dependencies.yml@main
+    permissions:
+      contents: write # Required to read workflow files
+      id-token: write # Required for dependency submission
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    uses: devops-actions/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/issue-pr-tag.yml
+++ b/.github/workflows/issue-pr-tag.yml
@@ -1,0 +1,28 @@
+
+name: "Issue/PR Tag"
+
+permissions:
+  contents: read
+
+# Trigger workflow when issues or pull requests are opened/edited,
+# or when this workflow file is modified
+on:
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  notify:
+    uses: devops-actions/.github/.github/workflows/issue-pr-tag.yml@main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    with:
+      org_name: devops-actions
+      tag_team: devops-actions-team
+      issue: ${{ github.event.issue.number }}
+      pr: ${{ github.event.pull_request.number }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the missing standard workflows to align with other repositories in the `devops-actions` organization.

## Changes

- ✅ **Added** `actions-dependencies.yml` - Submits GitHub Actions dependencies to dependency graph
- ✅ **Added** `issue-pr-tag.yml` - Automatically tags team when issues/PRs are opened
- ✅ **Added** `dependency-review.yml` - Scans PRs for vulnerable dependencies
- ✅ **Added** `actionlint.yml` - Lints GitHub Actions workflow files

All workflows use reusable workflows from `devops-actions/.github` repository.

## Benefits

- **Consistency**: Matches the standard workflow setup used by all other devops-actions repositories
- **Centralized maintenance**: Workflow updates happen in one place (`.github` repo)
- **Security**: Automatic dependency scanning and vulnerability detection
- **Quality**: Automatic workflow linting to catch errors

## Existing Workflows

This repo already has:
- ✅ approve-dependabot-pr (using reusable workflow)
- ✅ ossf-analysis (using reusable workflow)

Now all standard workflows are in place!