### PR TITLE
Validate README examples with shared checker workflow

### DIFF
--- a/.github/workflows/actions-example-checker.yml
+++ b/.github/workflows/actions-example-checker.yml
@@ -1,0 +1,12 @@
+name: Validate Action Examples
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  validate-examples:
+    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
Calls the shared reusable workflow from the org `.github` repo to validate YAML usage examples in documentation against `action.yml`.

- Adds `.github/workflows/actions-example-checker.yml`
- Runs on `push`, `pull_request`, and `workflow_dispatch`

Depends on the newly merged reusable workflow in `devops-actions/.github`.