### PR TITLE
fix: use org vars instead of hardcoded values in issue-pr-tag

### DIFF
--- a/.github/workflows/issue-pr-tag.yml
+++ b/.github/workflows/issue-pr-tag.yml
@@ -20,8 +20,8 @@ jobs:
       issues: write
       pull-requests: write
     with:
-      org_name: devops-actions
-      tag_team: devops-actions-team
+      org_name: ${{ vars.FIXED_ORG_NAME }}
+      tag_team: ${{ vars.TAG_TEAM }}
       issue: ${{ github.event.issue.number }}
       pr: ${{ github.event.pull_request.number }}
     secrets:


### PR DESCRIPTION
Use `vars.FIXED_ORG_NAME` and `vars.TAG_TEAM` in `issue-pr-tag.yml` instead of hardcoded `devops-actions` / `devops-actions-team`.