### PR TITLE
chore: upgrade action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ outputs:
   tag:
     description: Git tag name
 runs:
-  using: node20
+  using: node24
   main: main.js


### PR DESCRIPTION
Upgrades the action runtime from `node20` to `node24`, and updates CI workflows to use Node 24 as well.