### PR TITLE
fix: pin workflow dependencies to commit SHAs

### DIFF
--- a/.github/workflows/actions-example-checker.yml
+++ b/.github/workflows/actions-example-checker.yml
@@ -7,6 +7,6 @@ permissions:
 
 jobs:
   validate-examples:
-    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@main
+    uses: devops-actions/.github/.github/workflows/actions-example-checker.yml@ac988029b58dc9e66b496de47d8930ce737f89dc # main
     permissions:
       contents: read

--- a/.github/workflows/check-time-for-new-release.yml
+++ b/.github/workflows/check-time-for-new-release.yml
@@ -12,4 +12,4 @@ permissions:
   
 jobs:
   check-time-for-new-release:
-    uses: devops-actions/.github/.github/workflows/time-for-new-release.yml@main
+    uses: devops-actions/.github/.github/workflows/time-for-new-release.yml@ac988029b58dc9e66b496de47d8930ce737f89dc # main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Initialize Energy Estimation
-      uses: green-coding-berlin/eco-ci-energy-estimation@v5.3.0
+      uses: green-coding-berlin/eco-ci-energy-estimation@782dd4a31bc426a6ae26a7b08d89af454b10ffc0 # v5.3.0
       with:
         task: start-measurement
 
@@ -121,6 +121,6 @@ jobs:
         test "v0.99.0" = "${{steps.no_tag_dev_no_strip_v_default.outputs.tag}}"
 
     - name: Eco CI Energy Estimation
-      uses: green-coding-berlin/eco-ci-energy-estimation@v5.3.0
+      uses: green-coding-berlin/eco-ci-energy-estimation@782dd4a31bc426a6ae26a7b08d89af454b10ffc0 # v5.3.0
       with:
         task: get-measurement


### PR DESCRIPTION
## Summary

- Pins `green-coding-berlin/eco-ci-energy-estimation@v5.3.0` to its full commit SHA in `test.yml` (two occurrences)
- Pins `devops-actions/.github` reusable workflow calls from `@main` to a full commit SHA in `actions-example-checker.yml` and `check-time-for-new-release.yml`

Addresses code scanning alerts [#26](https://github.com/devops-actions/action-get-tag/security/code-scanning/26), [#29](https://github.com/devops-actions/action-get-tag/security/code-scanning/29), [#30](https://github.com/devops-actions/action-get-tag/security/code-scanning/30), and [#31](https://github.com/devops-actions/action-get-tag/security/code-scanning/31).

Note: The four `undici` vulnerability alerts (#25) are already resolved by the undici 6.27.0 bump in PR #125 — all four CVEs affect `< 6.27.0`. That alert will clear on the next scheduled scan.

## Test plan

- [ ] Verify the `Testing the action` workflow passes on this branch
- [ ] Confirm code scanning re-runs and the four pinned-dependency alerts close

🤖 Generated with [Claude Code](https://claude.com/claude-code)