### PR TITLE
feat: add Secure Input Scan reusable workflow

### DIFF
--- a/.github/workflows/secure-inputs.yml
+++ b/.github/workflows/secure-inputs.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   scan-inputs:
-    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@3bb5c8505eb368f90cf87956f0cc4d84cb8554d1 # main
+    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@3bb5c8505eb368f90cf87956f0cc4d84cb8554d1 # v1.1.0
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/secure-inputs.yml
+++ b/.github/workflows/secure-inputs.yml
@@ -1,0 +1,30 @@
+name: Secure Input Scan
+
+# Scans pull requests, issues, and comments for known attack vectors:
+# - Hidden Unicode characters incl. Unicode Tag Characters (AI instruction embedding)
+# - Bidirectional text overrides (Trojan Source)
+# - Shell / template / script injection
+# - Prompt injection targeting AI agents in CI/CD pipelines
+# See: devops-actions/.github/.github/workflows/secure-inputs.yml
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+  issues:
+    types: [opened, edited]
+
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  scan-inputs:
+    uses: devops-actions/.github/.github/workflows/secure-inputs.yml@3bb5c8505eb368f90cf87956f0cc4d84cb8554d1 # main
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
Adds the \devops-actions/.github\ secure-inputs.yml reusable workflow to scan pull requests, issues, and comments for known attack vectors: hidden Unicode (incl. Tag Characters for AI instruction embedding), bidirectional text overrides (Trojan Source), shell/template/script injection, and prompt injection targeting AI agents.

Pinned to the current \main\ SHA (\3bb5c85\, tagged \1.1.0\) of \devops-actions/.github\, matching the setup already rolled out to the rest of the org (see recent PRs across devops-actions repos).