### PR TITLE
fix: convert SPDX to CycloneDX locally to avoid broken gh-sbom CycloneDX API path

### DIFF
--- a/.github/workflows/time-for-new-release2.yml
+++ b/.github/workflows/time-for-new-release2.yml
@@ -105,6 +105,15 @@ jobs:
           # install the extension
           gh ext install advanced-security/gh-sbom
 
+          # install the CycloneDX CLI (.NET global tool) so we can convert the
+          # SPDX SBOM to CycloneDX locally, instead of using `gh sbom -c`.
+          # The CycloneDX code path in gh-sbom is a known, long-standing upstream bug
+          # (persistent 502 Bad Gateway / GraphQL timeout, since 2023):
+          # https://github.com/advanced-security/gh-sbom/issues/6
+          dotnet tool install --global CycloneDX
+          echo "$HOME/.dotnet/tools" >> $env:GITHUB_PATH
+          $env:PATH = "$HOME/.dotnet/tools:$env:PATH"
+
           $SPDX_SBOM_FILENAME="sbom-spdx.json"
           $CYCLONEDX_SBOM_FILENAME="sbom-cyclonedx.json"
 
@@ -135,9 +144,12 @@ jobs:
           $sbom = Invoke-GhSbomWithRetry -Arguments @('-l') | ConvertFrom-Json
           $sbom | ConvertTo-Json -Depth 100 >> $SPDX_SBOM_FILENAME
 
-          # run it for a CycloneDX SBOM
-          $sbom = Invoke-GhSbomWithRetry -Arguments @('-c', '-l') | ConvertFrom-Json
-          $sbom | ConvertTo-Json -Depth 100 >> $CYCLONEDX_SBOM_FILENAME
+          # convert the SPDX SBOM to a CycloneDX SBOM locally, rather than calling
+          # `gh sbom -c -l` (which hits the broken CycloneDX code path upstream)
+          cyclonedx convert --input-file $SPDX_SBOM_FILENAME --output-file $CYCLONEDX_SBOM_FILENAME --input-format spdxjson --output-format json
+          if ($LASTEXITCODE -ne 0) {
+            throw "cyclonedx convert failed with exit code $LASTEXITCODE"
+          }
 
           echo "SPDX_SBOM_FILENAME=$SPDX_SBOM_FILENAME" >> $env:GITHUB_OUTPUT
           echo "CYCLONEDX_SBOM_FILENAME=$CYCLONEDX_SBOM_FILENAME" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## Why

The CycloneDX code path in the [advanced-security/gh-sbom](https://github.com/advanced-security/gh-sbom) extension (\gh sbom -c\) is a known, long-standing, unresolved upstream bug. It hits a persistent 502 Bad Gateway / GraphQL timeout because it goes through GitHub's GraphQL dependency-graph API plus calls to \pi.clearlydefined.io\ for license enrichment - unlike SPDX, which uses a fast, reliable server-side REST endpoint.

See upstream issue: https://github.com/advanced-security/gh-sbom/issues/6 (open since 2023, still failing in 2026).

## What changed

- Stopped calling \gh sbom -c -l\ entirely.
- The SPDX SBOM is still generated via \gh sbom -l\ (kept behind the retry-with-backoff wrapper from #132, since transient 502s can still occasionally occur there too).
- The CycloneDX SBOM is now produced **locally** by converting the SPDX JSON using the [CycloneDX CLI](https://github.com/CycloneDX/cyclonedx-cli) (\cyclonedx convert --input-file ... --output-file ... --input-format spdxjson --output-format json\), installed as a .NET global tool (\dotnet tool install --global CycloneDX\) in the workflow step.
- Output variable names (\SPDX_SBOM_FILENAME\, \CYCLONEDX_SBOM_FILENAME\) are unchanged, so downstream steps (the 'temp for testing' cat step and the \gh release create\ step that attaches the CycloneDX file) keep working unchanged.

This PR is stacked on top of #132 (which added the SPDX retry wrapper) and targets that branch as its base.